### PR TITLE
fix wrong link

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -9,5 +9,5 @@ Redmine::Plugin.register :redmine_sidekiq do
   author_url 'mailto:ogom@hotmail.co.jp'
   author 'ogom'
 
-  menu :top_menu, :sidekiq, 'sidekiq', :if => Proc.new {User.current.admin}
+  menu :top_menu, :sidekiq, '/sidekiq', :if => Proc.new {User.current.admin}
 end


### PR DESCRIPTION
When clicking the sidekiq link from inside a redmine project or wiki the link is prefixed with the current url, which leads to a page not found. With this little fix the sidekiq overview is always found.