### PR TITLE
Add sidekiq 5 version support

### DIFF
--- a/lib/redmine_sidekiq/configure.rb
+++ b/lib/redmine_sidekiq/configure.rb
@@ -1,5 +1,10 @@
 require 'sidekiq'
 
+# Enable extensions if sidekiq version > 4
+if Sidekiq::Extensions.respond_to?(:enable_delay!)
+  Sidekiq::Extensions.enable_delay!
+end
+
 module RedmineSidekiq
   class Configure
     file = File.join(Rails.root, 'plugins/redmine_sidekiq/config/sidekiq.yml')


### PR DESCRIPTION
Without these lines plugin produce errors like "configure.rb:21:in `<class:Configure>': uninitialized constant Sidekiq::Extensions::ActiveRecord (NameError)"

In version 5 extensions is disabled by default.

https://github.com/mperham/sidekiq/wiki/Delayed-extensions